### PR TITLE
Fazer com que o APK-Debug compile no Actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,13 +21,13 @@ jobs:
         cache: gradle
 
     - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+      run: chmod +x gradlew
 
     - name: Build with Gradle
-        run: ./gradlew build
+      run: ./gradlew build
 
     - name: Upload APK-Debug
-        uses: actions/upload-artifact@v3
-        with:
-          name: neptune-engine-debug
-          path: app/build/outputs/apk/debug/app-debug.apk
+      uses: actions/upload-artifact@v3
+      with:
+        name: neptune-engine-debug
+        path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,6 +21,13 @@ jobs:
         cache: gradle
 
     - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
+        run: chmod +x gradlew
+
     - name: Build with Gradle
-      run: ./gradlew build
+        run: ./gradlew build
+
+    - name: Upload APK-Debug
+        uses: actions/upload-artifact@v3
+        with:
+          name: neptune-engine-debug
+          path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
Agora todas as compilações do GitHub Actions, será lançado o arquivo em APK na finalização da compilação.